### PR TITLE
exaple path, have to do all others

### DIFF
--- a/auto_git_pull.bat
+++ b/auto_git_pull.bat
@@ -1,8 +1,7 @@
 set "waittime=10" # the waitime between libraries pulls
 
-cd blink
+cd C:\Users\lieve\Documents\Github\Blink
 git pull
-cd ..
 timeout /t %waittime%
 
 cd core


### PR DESCRIPTION
the tested way of using paths instead of cd commands

avoids having cumulative issues if a path is removed or changed